### PR TITLE
Skip setup validation and action validation when loading game files

### DIFF
--- a/modules/jervis-engine/src/commonMain/kotlin/com/jervisffb/engine/rules/common/procedures/SetupTeam.kt
+++ b/modules/jervis-engine/src/commonMain/kotlin/com/jervisffb/engine/rules/common/procedures/SetupTeam.kt
@@ -160,7 +160,8 @@ object SetupTeam : Procedure() {
         override fun apply(state: Game, rules: Rules): Command {
             val context = state.getContext<SetupTeamContext>()
             val team = context.team
-            return when (rules.isSetupValid(state, team).isEmpty()) {
+            val valid = rules.allowPlayerEditsDuringGame || rules.isSetupValid(state, team).isEmpty()
+            return when (valid) {
                 true -> {
                     // If a player with Secret Weapon is on the pitch, we need to track it.
                     val trackSecretWeaponCommands = team

--- a/modules/jervis-engine/src/commonMain/kotlin/com/jervisffb/engine/serialize/JervisSerialization.kt
+++ b/modules/jervis-engine/src/commonMain/kotlin/com/jervisffb/engine/serialize/JervisSerialization.kt
@@ -142,7 +142,7 @@ object JervisSerialization {
             val serializedAwayTeam = jsonFormat.decodeFromJsonElement<SerializedTeam>(fileData.game.awayTeam)
             val awayTeam = SerializedTeam.deserialize(rules, serializedAwayTeam, unknownCoach)
             val state = Game(rules, homeTeam, awayTeam, Pitch.createForRuleset(rules))
-            val controller = GameEngineController(state, fileData.game.actions)
+            val controller = GameEngineController(state, fileData.game.actions, validateActions = false)
             val gameData = GameFileData(homeTeam, awayTeam, controller, fileData.game.actions)
             return Result.success(gameData)
         } catch (ex: Exception) {


### PR DESCRIPTION
## Why

Tools that reconstruct mid-game board states from replays (replay analyzers, coaching tools, puzzle generators) need the ability to place players at positions that violate setup rules — fewer than 3 on the LoS, wide zones unbalanced, etc. Currently, loading such a state via `JervisSerialization.loadFromFileContent` triggers `EndSetupAndValidate` which rejects the game file.

Similarly, game files saved at arbitrary mid-game states contain actions that were valid at save time but whose preconditions may no longer hold when replayed. Without `validateActions = false`, the controller rejects these actions on load, making checkpoint-based tooling impossible.

## What

Two targeted changes in `jervis-engine`:

- **`SetupTeam.kt`** — when `allowPlayerEditsDuringGame` is enabled (the same flag that gates the DevScreen's player-placement freedom in Jervis UI), the `EndSetupAndValidate` node is skipped entirely. This is checked alongside the existing `rules.isSetupValid()` call with a simple `||` short-circuit.

- **`JervisSerialization.kt`** — `loadFromFileContent` passes `validateActions = false` to the `GameEngineController` constructor. This is already the convention for replay playback in Jervis; game-file loading now follows the same pattern.

Both changes are gated behind existing flags (`allowPlayerEditsDuringGame`, already used by the Jervis DevScreen), so standard gameplay should be unaffected.
