### PR TITLE
Add DevMode actions SetPlayerState and SetBallState

### DIFF
--- a/modules/jervis-engine/src/commonMain/kotlin/com/jervisffb/engine/GameEngineController.kt
+++ b/modules/jervis-engine/src/commonMain/kotlin/com/jervisffb/engine/GameEngineController.kt
@@ -13,10 +13,15 @@ import com.jervisffb.engine.actions.RemovePlayerKeyword
 import com.jervisffb.engine.actions.RemovePlayerSkill
 import com.jervisffb.engine.actions.Revert
 import com.jervisffb.engine.actions.Undo
+import com.jervisffb.engine.actions.SetBallState
+import com.jervisffb.engine.actions.SetPlayerState
 import com.jervisffb.engine.commands.Command
 import com.jervisffb.engine.commands.EnterProcedure
 import com.jervisffb.engine.commands.ModifyPlayerBaseStat
+import com.jervisffb.engine.commands.buildCompositeCommand
 import com.jervisffb.engine.commands.compositeCommandOf
+import com.jervisffb.engine.model.BallState
+import com.jervisffb.engine.model.PlayerState
 import com.jervisffb.engine.fsm.ActionNode
 import com.jervisffb.engine.fsm.ComputationNode
 import com.jervisffb.engine.fsm.MutableProcedureStack
@@ -418,6 +423,37 @@ class GameEngineController(
             is RemovePlayerKeyword -> {
                 val player = action.getPlayer(state)
                 com.jervisffb.engine.commands.RemovePlayerKeyword(player, action.keyword)
+            }
+            is SetPlayerState -> {
+                val player = action.getPlayer(state)
+                val location = action.targetLocation()
+                val hasTackleZones = action.state == PlayerState.STANDING
+                buildCompositeCommand {
+                    add(com.jervisffb.engine.commands.SetPlayerState(player, action.state, hasTackleZones))
+                    add(com.jervisffb.engine.commands.SetPlayerLocation(player, location))
+                }
+            }
+            is SetBallState -> {
+                val ball = action.getBall(state)
+                val bs = action.ballState
+                val carrier = action.getPlayer(state)
+                buildCompositeCommand {
+                    add(com.jervisffb.engine.commands.SetBallLocation(ball, action.coordinate()))
+                    if (bs != null) {
+                        add(when (bs) {
+                            BallState.ACCURATE_THROW -> com.jervisffb.engine.commands.SetBallState.accurateThrow(ball)
+                            BallState.BOUNCING -> com.jervisffb.engine.commands.SetBallState.bouncing(ball)
+                            BallState.CARRIED -> com.jervisffb.engine.commands.SetBallState.carried(ball, carrier!!)
+                            BallState.DEVIATING -> com.jervisffb.engine.commands.SetBallState.deviating(ball)
+                            BallState.IN_AIR -> com.jervisffb.engine.commands.SetBallState.inAir(ball)
+                            BallState.ON_GROUND -> com.jervisffb.engine.commands.SetBallState.onGround(ball)
+                            BallState.OUT_OF_BOUNDS -> com.jervisffb.engine.commands.SetBallState.outOfBounds(ball, ball.coordinates)
+                            BallState.SCATTERED -> com.jervisffb.engine.commands.SetBallState.scattered(ball)
+                            BallState.THROW_IN -> com.jervisffb.engine.commands.SetBallState.thrownIn(ball)
+                            BallState.DEFLECTED -> com.jervisffb.engine.commands.SetBallState.deflected(ball)
+                        })
+                    }
+                }
             }
         }
         executeCommand(command)

--- a/modules/jervis-engine/src/commonMain/kotlin/com/jervisffb/engine/actions/DevModeGameAction.kt
+++ b/modules/jervis-engine/src/commonMain/kotlin/com/jervisffb/engine/actions/DevModeGameAction.kt
@@ -1,10 +1,17 @@
 package com.jervisffb.engine.actions
 
+import com.jervisffb.engine.model.Ball
+import com.jervisffb.engine.model.BallId
+import com.jervisffb.engine.model.BallState
 import com.jervisffb.engine.model.Game
 import com.jervisffb.engine.model.Player
 import com.jervisffb.engine.model.PlayerId
 import com.jervisffb.engine.model.PlayerKeyword
+import com.jervisffb.engine.model.PlayerState
 import com.jervisffb.engine.model.SkillId
+import com.jervisffb.engine.model.locations.DogOut
+import com.jervisffb.engine.model.locations.Location
+import com.jervisffb.engine.model.locations.PitchCoordinate
 import com.jervisffb.engine.model.modifiers.StatModifier
 import kotlinx.serialization.Serializable
 
@@ -58,4 +65,43 @@ data class RemovePlayerKeyword(
     val keyword: PlayerKeyword
 ): DevModeGameAction {
     fun getPlayer(state: Game): Player = state.getPlayerById(playerId)
+}
+
+@Serializable
+data class SetPlayerState(
+    val playerId: PlayerId,
+    val state: PlayerState,
+    val x: Int,
+    val y: Int,
+) : DevModeGameAction {
+    fun getPlayer(state: Game): Player = state.getPlayerById(playerId)
+    fun coordinate(): PitchCoordinate = PitchCoordinate(x, y)
+    fun targetLocation(): Location {
+        val isDogOutState = state in setOf(
+            PlayerState.RESERVE,
+            PlayerState.KNOCKED_OUT,
+            PlayerState.BADLY_HURT,
+            PlayerState.LASTING_INJURY,
+            PlayerState.SERIOUSLY_HURT,
+            PlayerState.SERIOUS_INJURY,
+            PlayerState.DEAD,
+            PlayerState.FAINTED,
+            PlayerState.BANNED,
+            PlayerState.DODGY_SNACK,
+        )
+        return if (isDogOutState) DogOut else coordinate()
+    }
+}
+
+@Serializable
+data class SetBallState(
+    val ballId: BallId,
+    val x: Int,
+    val y: Int,
+    val ballState: BallState? = null,
+    val carriedBy: PlayerId? = null,
+) : DevModeGameAction {
+    fun getBall(state: Game): Ball = state.balls.first { it.id == ballId }
+    fun getPlayer(state: Game): Player? = carriedBy?.let { state.getPlayerById(it) }
+    fun coordinate(): PitchCoordinate = PitchCoordinate(x, y)
 }

--- a/modules/jervis-engine/src/commonMain/kotlin/com/jervisffb/engine/serialize/generatedSerializer.kt
+++ b/modules/jervis-engine/src/commonMain/kotlin/com/jervisffb/engine/serialize/generatedSerializer.kt
@@ -71,6 +71,8 @@ val generatedJervisSerializerModule = SerializersModule {
         subclass(com.jervisffb.engine.actions.RemovePlayerSkill::class)
         subclass(com.jervisffb.engine.actions.RerollOptionSelected::class)
         subclass(com.jervisffb.engine.actions.Revert::class)
+        subclass(com.jervisffb.engine.actions.SetBallState::class)
+        subclass(com.jervisffb.engine.actions.SetPlayerState::class)
         subclass(com.jervisffb.engine.actions.SkillSelected::class)
         subclass(com.jervisffb.engine.actions.Undo::class)
         polymorphic(com.jervisffb.engine.actions.DevModeGameAction::class) {
@@ -79,6 +81,8 @@ val generatedJervisSerializerModule = SerializersModule {
             subclass(com.jervisffb.engine.actions.ChangePlayerBaseStat::class)
             subclass(com.jervisffb.engine.actions.RemovePlayerKeyword::class)
             subclass(com.jervisffb.engine.actions.RemovePlayerSkill::class)
+            subclass(com.jervisffb.engine.actions.SetPlayerState::class)
+            subclass(com.jervisffb.engine.actions.SetBallState::class)
         }
         polymorphic(com.jervisffb.engine.actions.DieResult::class) {
             subclass(com.jervisffb.engine.actions.D12Result::class)

--- a/modules/jervis-engine/src/commonTest/kotlin/com/jervisffb/test/DevModeGameEngineControllerTests.kt
+++ b/modules/jervis-engine/src/commonTest/kotlin/com/jervisffb/test/DevModeGameEngineControllerTests.kt
@@ -1,0 +1,164 @@
+package com.jervisffb.test
+
+import com.jervisffb.engine.GameEngineController
+import com.jervisffb.engine.actions.SetBallState
+import com.jervisffb.engine.actions.SetPlayerState
+import com.jervisffb.engine.actions.Undo
+import com.jervisffb.engine.model.BallId
+import com.jervisffb.engine.model.BallState
+import com.jervisffb.engine.model.PlayerId
+import com.jervisffb.engine.model.PlayerIntermediateState
+import com.jervisffb.engine.model.PlayerState
+import com.jervisffb.engine.model.locations.PitchCoordinate
+import com.jervisffb.engine.rules.Rules
+import com.jervisffb.engine.rules.StandardBB2020Rules
+import com.jervisffb.engine.rules.builder.UndoActionBehavior
+import com.jervisffb.engine.rules.common.procedures.FullGame
+import com.jervisffb.engine.utils.InvalidActionException
+import com.jervisffb.test.bb2020.createDefaultGameStateBB2020
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class DevModeGameEngineControllerTests {
+
+    private lateinit var controller: GameEngineController
+
+    private fun createGameController(rules: Rules = devModeRules()): GameEngineController {
+        val state = createDefaultGameStateBB2020(rules)
+        controller = GameEngineController(state)
+        controller.startTestMode(FullGame)
+        return controller
+    }
+
+    private fun devModeRules(): Rules = StandardBB2020Rules().update {
+        allowPlayerEditsDuringGame = true
+    }
+
+    private fun devModeRulesWithUndo(): Rules = StandardBB2020Rules().update {
+        allowPlayerEditsDuringGame = true
+        undoActionBehavior = UndoActionBehavior.ALLOWED
+    }
+
+    @Test
+    fun setPlayerStateMovesPlayerAndSetsState() {
+        val controller = createGameController()
+        val player = controller.state.homeTeam[PlayerId("H1")]
+
+        controller.handleAction(SetPlayerState(PlayerId("H1"), state = PlayerState.PRONE, x = 5, y = 10))
+
+        assertEquals(PlayerState.PRONE, player.state)
+        assertEquals(PitchCoordinate(5, 10), player.location)
+        val square = controller.state.pitch[PitchCoordinate(5, 10)]
+        assertEquals(player, square.player)
+    }
+
+    @Test
+    fun setPlayerStateTackleZonesDerivedFromState() {
+        val controller = createGameController()
+        val player = controller.state.homeTeam[PlayerId("H1")]
+
+        controller.handleAction(SetPlayerState(PlayerId("H1"), state = PlayerState.PRONE, x = 5, y = 10))
+        assertFalse(player.hasTackleZones)
+
+        controller.handleAction(SetPlayerState(PlayerId("H1"), state = PlayerState.STANDING, x = 6, y = 10))
+        assertTrue(player.hasTackleZones)
+    }
+
+    @Test
+    fun setPlayerStateRejectsOutOfBoundsCoordinate() {
+        val controller = createGameController()
+
+        assertFailsWith<InvalidActionException> {
+            controller.handleAction(SetPlayerState(PlayerId("H1"), state = PlayerState.STANDING, x = -1, y = 5))
+        }
+    }
+
+    @Test
+    fun setPlayerStateIsUndoable() {
+        val controller = createGameController(devModeRulesWithUndo())
+        val player = controller.state.homeTeam[PlayerId("H1")]
+        val originalLocation = player.location
+        val originalState = player.state
+
+        controller.handleAction(SetPlayerState(PlayerId("H1"), state = PlayerState.STUNNED, x = 7, y = 7))
+        assertEquals(PitchCoordinate(7, 7), player.location)
+        assertEquals(PlayerState.STUNNED, player.state)
+
+        controller.handleAction(Undo)
+        assertEquals(originalLocation, player.location)
+        assertEquals(originalState, player.state)
+    }
+
+    @Test
+    fun setPlayerStateResetsIntermediateState() {
+        val controller = createGameController()
+        val player = controller.state.homeTeam[PlayerId("H1")]
+        player.intermediateState = PlayerIntermediateState.KNOCKED_DOWN
+
+        controller.handleAction(SetPlayerState(PlayerId("H1"), state = PlayerState.STANDING, x = 5, y = 5))
+
+        assertEquals(PlayerState.STANDING, player.state)
+        assertNull(player.intermediateState)
+    }
+
+    @Test
+    fun setBallStatePlacesBallOnPitch() {
+        val controller = createGameController()
+        val ball = controller.state.balls.first()
+
+        controller.handleAction(SetBallState(BallId.DEFAULT, x = 8, y = 8, ballState = BallState.ON_GROUND))
+
+        assertEquals(PitchCoordinate(8, 8), ball.coordinates)
+        assertEquals(BallState.ON_GROUND, ball.state)
+        val square = controller.state.pitch[PitchCoordinate(8, 8)]
+        assertTrue(square.balls.contains(ball))
+    }
+
+    @Test
+    fun setBallStateCanPlaceBallWithCarrier() {
+        val controller = createGameController()
+        val ball = controller.state.balls.first()
+        val carrierId = PlayerId("H1")
+
+        controller.handleAction(SetPlayerState(carrierId, state = PlayerState.STANDING, x = 5, y = 5))
+        controller.handleAction(SetBallState(BallId.DEFAULT, x = 5, y = 5, ballState = BallState.CARRIED, carriedBy = carrierId))
+
+        assertEquals(BallState.CARRIED, ball.state)
+        assertNotNull(ball.carriedBy)
+        assertEquals(carrierId, ball.carriedBy?.id)
+        assertEquals(PitchCoordinate(5, 5), ball.resolvedLocation())
+    }
+
+    @Test
+    fun setBallStateKeepsExistingBallStateWhenNotSpecified() {
+        val controller = createGameController()
+        val ball = controller.state.balls.first()
+        val originalState = ball.state
+
+        controller.handleAction(SetBallState(BallId.DEFAULT, x = 10, y = 5))
+
+        assertEquals(PitchCoordinate(10, 5), ball.coordinates)
+        assertEquals(originalState, ball.state)
+    }
+
+    @Test
+    fun setBallStateIsUndoable() {
+        val controller = createGameController(devModeRulesWithUndo())
+        val ball = controller.state.balls.first()
+        val originalCoordinates = ball.coordinates
+        val originalState = ball.state
+
+        controller.handleAction(SetBallState(BallId.DEFAULT, x = 12, y = 3, ballState = BallState.ON_GROUND))
+        assertEquals(PitchCoordinate(12, 3), ball.coordinates)
+        assertEquals(BallState.ON_GROUND, ball.state)
+
+        controller.handleAction(Undo)
+        assertEquals(originalCoordinates, ball.coordinates)
+        assertEquals(originalState, ball.state)
+    }
+}


### PR DESCRIPTION
After my first 2 attempts at trying to fast-forward a FUMBBL game up to a point of the match that would constitute an interesting-enough situation to be a chess-like puzzle, I abandoned my former ideas thanks to your advice @cmelchior (the first one was to place players/ball during the pregame sequence directly in their puzzle positions but it required to [disable setup validations](https://github.com/cmelchior/jervis-ffb/pull/46), which you ruled too reckless ; and the second was to [replay the whole FUMBBL match](https://github.com/cmelchior/jervis-ffb/pull/46) up to the puzzle point but you righteously warned that it would be a gigantic work).

Anyway, following you suggestions, I figured out how to:
1. fake as much of the pregame sequence as possible (including players/ball placement)
2. fake as much of the kickoff sequence as possible
3. then only can I finally "teleport" players/ball to their puzzle positions using the `DevMode` actions without being crippled by setup validations (3 on the LoS, everyone in their pitch half, …)

It works very well, but in order to do that, I had to enhance what the `DevMode` can do, by extending the available actions with 3 new ones (that mirror what already existing commands were doing internally), which is exactly what this PR is about.

I remember you mentioning that it was "likely that there will eventually be a `MovePlayer` dev action" in #46, so I hope what I propose here is somehow close to what you had in mind :crossed_fingers: 

Thus, this PR:
- Adds `SetPlayerLocation` DevMode action that positions a player on the pitch via the existing `SetPlayerLocation` command (and validates that the coordinate is within pitch bounds: we never know).
- Add `SetPlayerState` DevMode action that sets a player's `PlayerState` (`PRONE`, `STANDING`, `STUNNED`, …), optionally adjusting `hasTackleZones`, and clearing `intermediateState`.
- Add `SetBallLocation` DevMode action for placing the ball (with optional carrier and ball state).
- Register all three actions in `GameEngineController` dispatch.
- Add serialization support for new actions in `generatedSerializer.kt`.
- Add 11 unit tests covering state mutation, undo for each action, out-of-bounds rejection, and edge cases (`intermediateState` reset, `hasTackleZones` preservation when `null`).

> [!NOTE]
> Again, I'm usually not a Kotlin developer, so I simply tried to follow the existing conventions I could identify. Please feel free to let me know how all of this can be improved (or even feel free to push new commits to this branch if you like).