### PR TITLE
Update Chaos Dwarf roster to match official BB2025 data

### DIFF
--- a/modules/jervis-resources/src/commonMain/kotlin/com/jervisffb/resources/bb2025/ChaosDwarfTeam.kt
+++ b/modules/jervis-resources/src/commonMain/kotlin/com/jervisffb/resources/bb2025/ChaosDwarfTeam.kt
@@ -1,5 +1,6 @@
 package com.jervisffb.resources.bb2025
 
+import com.jervisffb.engine.model.PlayerKeyword
 import com.jervisffb.engine.model.PlayerSize
 import com.jervisffb.engine.model.PositionId
 import com.jervisffb.engine.model.RosterId
@@ -7,12 +8,27 @@ import com.jervisffb.engine.rules.common.roster.RegionalSpecialRule
 import com.jervisffb.engine.rules.common.roster.Roster
 import com.jervisffb.engine.rules.common.roster.RosterPosition
 import com.jervisffb.engine.rules.common.roster.TeamSpecialRule
-import com.jervisffb.engine.rules.common.skills.SkillCategory
+import com.jervisffb.engine.rules.common.skills.SkillCategory.AGILITY
+import com.jervisffb.engine.rules.common.skills.SkillCategory.DEVIOUS
+import com.jervisffb.engine.rules.common.skills.SkillCategory.GENERAL
+import com.jervisffb.engine.rules.common.skills.SkillCategory.MUTATIONS
+import com.jervisffb.engine.rules.common.skills.SkillCategory.STRENGTH
 import com.jervisffb.engine.rules.common.skills.SkillType.BLOCK
+import com.jervisffb.engine.rules.common.skills.SkillType.BRAWLER
+import com.jervisffb.engine.rules.common.skills.SkillType.BREATHE_FIRE
+import com.jervisffb.engine.rules.common.skills.SkillType.DISTURBING_PRESENCE
+import com.jervisffb.engine.rules.common.skills.SkillType.FRENZY
+import com.jervisffb.engine.rules.common.skills.SkillType.HORNS
+import com.jervisffb.engine.rules.common.skills.SkillType.IRON_HARD_SKIN
+import com.jervisffb.engine.rules.common.skills.SkillType.LONER
+import com.jervisffb.engine.rules.common.skills.SkillType.MIGHTY_BLOW
+import com.jervisffb.engine.rules.common.skills.SkillType.SHADOWING
 import com.jervisffb.engine.rules.common.skills.SkillType.SPRINT
+import com.jervisffb.engine.rules.common.skills.SkillType.STAB
 import com.jervisffb.engine.rules.common.skills.SkillType.SURE_FEET
-import com.jervisffb.engine.rules.common.skills.SkillType.TACKLE
 import com.jervisffb.engine.rules.common.skills.SkillType.THICK_SKULL
+import com.jervisffb.engine.rules.common.skills.SkillType.UNCHANNELLED_FURY
+import com.jervisffb.engine.rules.common.skills.SkillType.UNSTEADY
 import com.jervisffb.engine.serialize.RosterLogo
 import com.jervisffb.engine.serialize.SingleSprite
 import com.jervisffb.engine.serialize.SpriteSheet
@@ -30,32 +46,77 @@ val HOBGOBLIN_LINEMEN =
         40_000,
         6, 3, 3, 4, 8,
         emptyList(),
-        listOf(SkillCategory.GENERAL),
-        listOf(SkillCategory.AGILITY, SkillCategory.STRENGTH),
+        listOf(DEVIOUS),
+        listOf(GENERAL, AGILITY, STRENGTH),
         emptyList(),
-        emptyList(),
+        listOf(PlayerKeyword.GOBLIN, PlayerKeyword.LINEMAN),
         PlayerSize.STANDARD,
-        SpriteSheet.ini("${iconRootPath}/chaosdwarf_hobgoblinlineman.png", 10),
-        SingleSprite.ini("${portraitRootPath}/chaosdwarf_hobgoblinlineman.png")
+        SpriteSheet.ini("${iconRootPath}/chaosdwarf_hobgoblin.png", 10),
+        SingleSprite.ini("${portraitRootPath}/chaosdwarf_hobgoblin.png")
     )
+
+val SNEAKY_STABBAS =
+    RosterPosition(
+        PositionId("chaos-dwarf-sneaky-stabba"),
+        2,
+        "Sneaky Stabbas",
+        "Sneaky Stabba",
+        "S",
+        60_000,
+        6, 3, 3, 5, 8,
+        listOf(SHADOWING.id(), STAB.id()),
+        listOf(GENERAL, DEVIOUS),
+        listOf(AGILITY, STRENGTH),
+        emptyList(),
+        listOf(PlayerKeyword.GOBLIN, PlayerKeyword.SPECIAL),
+        PlayerSize.STANDARD,
+        SpriteSheet.ini("${iconRootPath}/chaosdwarf_hobgoblinsneakystabba.png", 2),
+        SingleSprite.ini("${portraitRootPath}/chaosdwarf_hobgoblinsneakystabba.png")
+    )
+
 val CHAOS_DWARF_BLOCKERS =
     RosterPosition(
         PositionId("chaos-dwarf-chaos-dwarf-blocker"),
-        6,
+        4,
         "Chaos Dwarf Blockers",
         "Chaos Dwarf Blocker",
         "Cd",
         70_000,
         4, 3, 4, 6, 10,
-        listOf(BLOCK.id(), TACKLE.id(), THICK_SKULL.id()),
-        listOf(SkillCategory.GENERAL, SkillCategory.STRENGTH),
-        listOf(SkillCategory.AGILITY, SkillCategory.MUTATIONS),
+        listOf(BLOCK.id(), IRON_HARD_SKIN.id(), THICK_SKULL.id()),
+        listOf(GENERAL, STRENGTH),
+        listOf(AGILITY, DEVIOUS, MUTATIONS),
         emptyList(),
-        emptyList(),
+        listOf(PlayerKeyword.DWARF, PlayerKeyword.BLOCKER),
         PlayerSize.STANDARD,
         SpriteSheet.ini("${iconRootPath}/chaosdwarf_chaosdwarfblocker.png", 6),
         SingleSprite.ini("${portraitRootPath}/chaosdwarf_chaosdwarfblocker.png")
     )
+
+val FLAMESMITHS =
+    RosterPosition(
+        PositionId("chaos-dwarf-flamesmith"),
+        2,
+        "Flamesmiths",
+        "Flamesmith",
+        "F",
+        80_000,
+        5, 3, 4, 6, 10,
+        listOf(
+            DISTURBING_PRESENCE.id(),
+            BRAWLER.id(),
+            THICK_SKULL.id(),
+            BREATHE_FIRE.id()
+        ),
+        listOf(GENERAL, STRENGTH),
+        listOf(AGILITY, DEVIOUS, MUTATIONS),
+        emptyList(),
+        listOf(PlayerKeyword.DWARF, PlayerKeyword.SPECIAL),
+        PlayerSize.STANDARD,
+        SpriteSheet.ini("${iconRootPath}/chaosdwarf_chaosdwarfflamesmith.png", 2),
+        SingleSprite.ini("${portraitRootPath}/chaosdwarf_chaosdwarfflamesmith.png")
+    )
+
 val BULL_CENTAUR_BLITZERS =
     RosterPosition(
         PositionId("chaos-dwarf-bull-centaur-blitzer"),
@@ -69,15 +130,17 @@ val BULL_CENTAUR_BLITZERS =
             SPRINT.id(),
             SURE_FEET.id(),
             THICK_SKULL.id(),
+            UNSTEADY.id()
         ),
-        listOf(SkillCategory.GENERAL, SkillCategory.STRENGTH),
-        listOf(SkillCategory.AGILITY),
+        listOf(GENERAL, STRENGTH),
+        listOf(AGILITY, DEVIOUS, MUTATIONS),
         emptyList(),
-        emptyList(),
+        listOf(PlayerKeyword.DWARF, PlayerKeyword.BLITZER),
         PlayerSize.STANDARD,
         SpriteSheet.ini("${iconRootPath}/chaosdwarf_bullcentaurblitzer.png", 2),
         SingleSprite.ini("${portraitRootPath}/chaosdwarf_bullcentaurblitzer.png")
     )
+
 val ENSLAVED_MINOTAUR =
     RosterPosition(
         PositionId("chaos-dwarf-enslaved-minotaur"),
@@ -86,18 +149,24 @@ val ENSLAVED_MINOTAUR =
         "Enslaved Minotaur",
         "M",
         150_000,
-        5, 5, 4, 0, 9,
+        5, 5, 4, 6, 9,
+        listOf(
+            FRENZY.id(),
+            HORNS.id(),
+            MIGHTY_BLOW.id(),
+            THICK_SKULL.id(),
+            LONER.idTarget(4),
+            UNCHANNELLED_FURY.id()
+        ),
+        listOf(STRENGTH, MUTATIONS),
+        listOf(GENERAL, AGILITY),
         emptyList(),
-        listOf(SkillCategory.AGILITY, SkillCategory.GENERAL),
-        listOf(SkillCategory.STRENGTH, SkillCategory.PASSING),
-        emptyList(),
-        emptyList(),
+        listOf(PlayerKeyword.MINOTAUR, PlayerKeyword.BIG_GUY),
         PlayerSize.BIG_GUY,
-        SpriteSheet.ini("${iconRootPath}/chaosdwarf_enslavedminotaur.png",1),
+        SpriteSheet.ini("${iconRootPath}/chaosdwarf_enslavedminotaur.png", 1),
         SingleSprite.ini("${portraitRootPath}/chaosdwarf_enslavedminotaur.png")
     )
 
-// See Teams of Legend: https://www.warhammer-community.com/wp-content/uploads/2020/11/lFZy1SIuNmWvxPj1.pdf
 @Serializable
 val CHAOS_DWARF_TEAM_BB2025 = Roster(
     id = RosterId("jervis-chaos-dwarf"),
@@ -108,7 +177,9 @@ val CHAOS_DWARF_TEAM_BB2025 = Roster(
     allowApothecary = true,
     positions = listOf(
         HOBGOBLIN_LINEMEN,
+        SNEAKY_STABBAS,
         CHAOS_DWARF_BLOCKERS,
+        FLAMESMITHS,
         BULL_CENTAUR_BLITZERS,
         ENSLAVED_MINOTAUR,
     ),


### PR DESCRIPTION
Brings the Chaos Dwarf BB2025 roster in line with all four checked reference sources: French rulebook (page 164), FUMBBL API, Mordorbihan and BloodBowlBase.

Changes:
- Fix Hobgoblin Lineman primary/secondary skill categories
- Fix Chaos Dwarf Blocker qty (6->4), replace Tackle with Iron Hard Skin
- Add Unsteady to Bull Centaur Blitzer skills
- Fix Enslaved Minotaur PA (0->6), skills, and categories
- Add Sneaky Stabba (0-2, 60K) position with Shadowing/Stab
- Add Flamesmith (0-2, 80K) position
- Add PlayerKeyword to all positionals