### PR TITLE
Update Elven Union roster to BB2025

### DIFF
--- a/modules/jervis-resources/src/commonMain/kotlin/com/jervisffb/resources/bb2025/ElvenUnionTeam.kt
+++ b/modules/jervis-resources/src/commonMain/kotlin/com/jervisffb/resources/bb2025/ElvenUnionTeam.kt
@@ -1,16 +1,25 @@
 package com.jervisffb.resources.bb2025
 
+import com.jervisffb.engine.model.PlayerKeyword
 import com.jervisffb.engine.model.PlayerSize
 import com.jervisffb.engine.model.PositionId
 import com.jervisffb.engine.model.RosterId
 import com.jervisffb.engine.rules.common.roster.RegionalSpecialRule
 import com.jervisffb.engine.rules.common.roster.Roster
 import com.jervisffb.engine.rules.common.roster.RosterPosition
-import com.jervisffb.engine.rules.common.skills.SkillCategory
+import com.jervisffb.engine.rules.common.skills.SkillCategory.AGILITY
+import com.jervisffb.engine.rules.common.skills.SkillCategory.GENERAL
+import com.jervisffb.engine.rules.common.skills.SkillCategory.PASSING
+import com.jervisffb.engine.rules.common.skills.SkillCategory.STRENGTH
 import com.jervisffb.engine.rules.common.skills.SkillType
 import com.jervisffb.engine.rules.common.skills.SkillType.BLOCK
 import com.jervisffb.engine.rules.common.skills.SkillType.CATCH
+import com.jervisffb.engine.rules.common.skills.SkillType.DIVING_CATCH
+import com.jervisffb.engine.rules.common.skills.SkillType.FUMBLEROOSKI
+import com.jervisffb.engine.rules.common.skills.SkillType.HAIL_MARY_PASS
+import com.jervisffb.engine.rules.common.skills.SkillType.NERVES_OF_STEEL
 import com.jervisffb.engine.rules.common.skills.SkillType.PASS
+import com.jervisffb.engine.rules.common.skills.SkillType.SIDESTEP
 import com.jervisffb.engine.serialize.RosterLogo
 import com.jervisffb.engine.serialize.SingleSprite
 import com.jervisffb.engine.serialize.SpriteSheet
@@ -21,17 +30,17 @@ import kotlinx.serialization.Serializable
 val ELVEN_LINEMAN =
     RosterPosition(
         PositionId("elven-union-lineman"),
-        12,
-        "Lineman",
+        16,
+        "Linemen",
         "Lineman",
         "L",
-        60_000,
-        6, 3, 2, 4, 8,
+        65_000,
+        6, 3, 2, 3, 8,
+        listOf(FUMBLEROOSKI.id()),
+        listOf(GENERAL, AGILITY),
+        listOf(STRENGTH),
         emptyList(),
-        listOf(SkillCategory.AGILITY, SkillCategory.GENERAL),
-        listOf(SkillCategory.GENERAL),
-        emptyList(),
-        emptyList(),
+        listOf(PlayerKeyword.ELF, PlayerKeyword.LINEMAN),
         PlayerSize.STANDARD,
         SpriteSheet.ini("${iconRootPath}/elvenunion_lineman.png",8),
         SingleSprite.ini("${portraitRootPath}/elvenunion_lineman.png")
@@ -45,11 +54,11 @@ val ELVEN_THROWER =
         "T",
         75_000,
         6, 3, 2, 2, 8,
-        listOf(PASS.id()),
-        listOf(SkillCategory.AGILITY, SkillCategory.GENERAL, SkillCategory.PASSING),
-        listOf(SkillCategory.GENERAL),
+        listOf(HAIL_MARY_PASS.id(), PASS.id()),
+        listOf(GENERAL, AGILITY, PASSING),
+        listOf(STRENGTH),
         emptyList(),
-        emptyList(),
+        listOf(PlayerKeyword.ELF, PlayerKeyword.THROWER),
         PlayerSize.STANDARD,
         SpriteSheet.ini("${iconRootPath}/elvenunion_thrower.png",2),
         SingleSprite.ini("${portraitRootPath}/elvenunion_thrower.png")
@@ -57,17 +66,17 @@ val ELVEN_THROWER =
 val ELVEN_CATCHER =
     RosterPosition(
         PositionId("elven-union-catcher"),
-        4,
+        2,
         "Catchers",
         "Catcher",
         "C",
         100_000,
-        8, 3, 3, 4, 8,
-        listOf(CATCH.id(), /* Nerves Of Steel */),
-        listOf(SkillCategory.AGILITY, SkillCategory.GENERAL),
-        listOf(SkillCategory.GENERAL),
+        8, 3, 2, 4, 8,
+        listOf(CATCH.id(), DIVING_CATCH.id(), NERVES_OF_STEEL.id()),
+        listOf(GENERAL, AGILITY),
+        listOf(STRENGTH),
         emptyList(),
-        emptyList(),
+        listOf(PlayerKeyword.ELF, PlayerKeyword.CATCHER),
         PlayerSize.STANDARD,
         SpriteSheet.ini("${iconRootPath}/elvenunion_catcher.png", 4),
         SingleSprite.ini("${portraitRootPath}/elvenunion_catcher.png")
@@ -81,11 +90,11 @@ val ELVEN_BLITZER =
         "B",
         115_000,
         7, 3, 2, 3, 9,
-        listOf(BLOCK.id(), SkillType.SIDESTEP.id()),
-        listOf(SkillCategory.GENERAL, SkillCategory.GENERAL),
-        listOf(SkillCategory.AGILITY, SkillCategory.PASSING),
+        listOf(BLOCK.id(), SIDESTEP.id()),
+        listOf(GENERAL, AGILITY),
+        listOf(PASSING, STRENGTH),
         emptyList(),
-        emptyList(),
+        listOf(PlayerKeyword.ELF, PlayerKeyword.BLITZER),
         PlayerSize.STANDARD,
         SpriteSheet.ini("${iconRootPath}/elvenunion_blitzer.png", 2),
         SingleSprite.ini("${portraitRootPath}/elvenunion_blitzer.png")
@@ -93,7 +102,7 @@ val ELVEN_BLITZER =
 
 @Serializable
 val ELVEN_UNION_TEAM_BB2025 = Roster(
-    id = RosterId("jervis-elvish-union"),
+    id = RosterId("jervis-elven-union"),
     name = "Elven Union",
     tier = 2,
     numberOfRerolls = 8,


### PR DESCRIPTION
Aligns the Elven Union BB2025 roster with the official Blood Bowl 2025 rulebook data (French rulebook page 168). All changes cross-verified against FUMBBL API (roster 8598, ruleset 3906 — which is wrong on the max number of linemen, btw :confused:), Mordorbihan, and BloodBowlBase.

Changes:
- Elf Lineman: qty 12->16, cost 60K->65K, PA 4+->3+, add Fumblerooski, fix keywords
- Elf Thrower: add Hail Mary Pass, fix keywords
- Elf Catcher: qty 4->2, AG 3+->2+, add Diving Catch + Nerves of Steel, fix keywords
- Elf Blitzer: fix primary/secondary categories, add keywords
- Add PlayerKeyword imports for all positionals
- Fix RosterId typo ("elvish-union" -> "elven-union")