### PR TITLE
Update Khorne roster to BB2025

### DIFF
--- a/modules/jervis-resources/src/commonMain/kotlin/com/jervisffb/resources/bb2025/KhorneTeam.kt
+++ b/modules/jervis-resources/src/commonMain/kotlin/com/jervisffb/resources/bb2025/KhorneTeam.kt
@@ -1,5 +1,6 @@
 package com.jervisffb.resources.bb2025
 
+import com.jervisffb.engine.model.PlayerKeyword
 import com.jervisffb.engine.model.PlayerSize
 import com.jervisffb.engine.model.PositionId
 import com.jervisffb.engine.model.RosterId
@@ -8,10 +9,21 @@ import com.jervisffb.engine.rules.common.roster.Roster
 import com.jervisffb.engine.rules.common.roster.RosterPosition
 import com.jervisffb.engine.rules.common.roster.TeamSpecialRule
 import com.jervisffb.engine.rules.common.skills.SkillCategory
+import com.jervisffb.engine.rules.common.skills.SkillCategory.AGILITY
+import com.jervisffb.engine.rules.common.skills.SkillCategory.DEVIOUS
+import com.jervisffb.engine.rules.common.skills.SkillCategory.GENERAL
+import com.jervisffb.engine.rules.common.skills.SkillCategory.MUTATIONS
+import com.jervisffb.engine.rules.common.skills.SkillCategory.PASSING
+import com.jervisffb.engine.rules.common.skills.SkillCategory.STRENGTH
 import com.jervisffb.engine.rules.common.skills.SkillType
+import com.jervisffb.engine.rules.common.skills.SkillType.CLAWS
 import com.jervisffb.engine.rules.common.skills.SkillType.FRENZY
 import com.jervisffb.engine.rules.common.skills.SkillType.HORNS
+import com.jervisffb.engine.rules.common.skills.SkillType.JUMP_UP
+import com.jervisffb.engine.rules.common.skills.SkillType.JUGGERNAUT
 import com.jervisffb.engine.rules.common.skills.SkillType.LONER
+import com.jervisffb.engine.rules.common.skills.SkillType.MIGHTY_BLOW
+import com.jervisffb.engine.rules.common.skills.SkillType.THICK_SKULL
 import com.jervisffb.engine.rules.common.skills.SkillType.UNCHANNELLED_FURY
 import com.jervisffb.engine.serialize.RosterLogo
 import com.jervisffb.engine.serialize.SingleSprite
@@ -29,10 +41,10 @@ val BLOODBORN_MARAUDER_LINEMEN =
         50_000,
         6, 3, 3, 4, 8,
         listOf(FRENZY.id()),
-        listOf(SkillCategory.GENERAL, SkillCategory.MUTATIONS),
-        listOf(SkillCategory.AGILITY, SkillCategory.STRENGTH),
+        listOf(GENERAL, MUTATIONS),
+        listOf(AGILITY, STRENGTH, DEVIOUS),
         emptyList(),
-        emptyList(),
+        listOf(PlayerKeyword.HUMAN, PlayerKeyword.LINEMAN),
         PlayerSize.STANDARD,
         SpriteSheet.ini("${iconRootPath}/khorne_bloodbornmarauderlineman.png",7),
         SingleSprite.ini("${portraitRootPath}/khorne_bloodbornmarauderlineman.png")
@@ -40,19 +52,19 @@ val BLOODBORN_MARAUDER_LINEMEN =
 val KHORNGORS =
     RosterPosition(
         PositionId("khorne-khorngor"),
-        4,
+        2,
         "Khorngors",
         "Khorngor",
         "K",
         70_000,
-        6, 3, 4, 4, 9,
-        listOf(HORNS.id() /*, Juggernaut */),
-        listOf(SkillCategory.GENERAL, SkillCategory.MUTATIONS, SkillCategory.STRENGTH),
-        listOf(SkillCategory.AGILITY, SkillCategory.PASSING),
+        6, 3, 3, 4, 9,
+        listOf(HORNS.id(), JUMP_UP.id(), JUGGERNAUT.id(), THICK_SKULL.id()),
+        listOf(GENERAL, MUTATIONS, STRENGTH),
+        listOf(AGILITY, PASSING, DEVIOUS),
         emptyList(),
-        emptyList(),
+        listOf(PlayerKeyword.BEASTMAN, PlayerKeyword.RUNNER),
         PlayerSize.STANDARD,
-        SpriteSheet.ini("${iconRootPath}/khorne_khorngor.png",4),
+        SpriteSheet.ini("${iconRootPath}/khorne_khorngor.png",2),
         SingleSprite.ini("${portraitRootPath}/khorne_khorngor.png")
     )
 val BLOODSEEKERS =
@@ -62,13 +74,13 @@ val BLOODSEEKERS =
         "Bloodseekers",
         "Bloodseeker",
         "Bs",
-        110_000,
+        105_000,
         5, 4, 4, 6, 10,
         listOf(FRENZY.id()),
-        listOf(SkillCategory.GENERAL, SkillCategory.MUTATIONS, SkillCategory.STRENGTH),
-        listOf(SkillCategory.AGILITY),
+        listOf(GENERAL, MUTATIONS, STRENGTH),
+        listOf(AGILITY, DEVIOUS),
         emptyList(),
-        emptyList(),
+        listOf(PlayerKeyword.HUMAN, PlayerKeyword.BLOCKER),
         PlayerSize.STANDARD,
         SpriteSheet.ini("${iconRootPath}/khorne_bloodseeker.png", 4),
         SingleSprite.ini("${portraitRootPath}/khorne_bloodseeker.png")
@@ -81,18 +93,18 @@ val BLOODSPAWN =
         "Bloodspawn",
         "B",
         160_000,
-        5, 5, 4, null, 9,
+        5, 5, 4, 6, 9,
         listOf(
-            // Claws
+            CLAWS.id(),
             FRENZY.id(),
             LONER.idTarget(4),
-            SkillType.MIGHTY_BLOW.idAdjustment(1),
+            MIGHTY_BLOW.idAdjustment(1),
             UNCHANNELLED_FURY.id()
         ),
-        listOf(SkillCategory.MUTATIONS, SkillCategory.STRENGTH),
-        listOf(SkillCategory.AGILITY, SkillCategory.GENERAL),
+        listOf(MUTATIONS, STRENGTH),
+        listOf(AGILITY, GENERAL),
         emptyList(),
-        emptyList(),
+        listOf(PlayerKeyword.SPAWN, PlayerKeyword.BIG_GUY),
         PlayerSize.BIG_GUY,
         SpriteSheet.ini("${iconRootPath}/khorne_bloodspawn.png", 1),
         SingleSprite.ini("${portraitRootPath}/khorne_bloodspawn.png")
@@ -101,7 +113,7 @@ val BLOODSPAWN =
 // See Spike! Journal Issue 13
 val KHORNE_TEAM_BB2025 = Roster(
     id = RosterId("jervis-khorne"),
-    tier = 2,
+    tier = 3,
     name = "Khorne Team",
     numberOfRerolls = 8,
     rerollCost = 60_000,


### PR DESCRIPTION
- Fix Khorngor quantity from 4 to 2, AG from 4 to 3
- Fix Bloodseeker cost from 110K to 105K
- Fix Bloodspawn PA from null to 6, uncomment Claws skill
- Add missing skills: Jump Up, Juggernaut, Thick Skull to Khorngor; Claws to Bloodspawn
- Add missing DEVIOUS secondary access to Bloodborn Marauder, Khorngor, Bloodseeker
- Add PlayerKeyword lists to all positionals (Human/Lineman, Beastman/Runner, Human/Blocker, Spawn/Big Guy)
- Fix team tier from 2 to 3
- All values verified against:
  - French rulebook page 174
  - FUMBBL API (roster 8591)
  - Mordorbihan
  - BloodBowlBase