### PR TITLE
Fix FUMBBL→Jervis extra-skill classification and BB2025 roster mapping

### DIFF
--- a/modules/fumbbl-net/src/commonMain/kotlin/com/jervisffb/fumbbl/net/utils/utils.kt
+++ b/modules/fumbbl-net/src/commonMain/kotlin/com/jervisffb/fumbbl/net/utils/utils.kt
@@ -9,17 +9,33 @@ import com.jervisffb.engine.model.PlayerNo
 import com.jervisffb.engine.model.SkillId
 import com.jervisffb.engine.model.Team
 import com.jervisffb.engine.rules.Rules
+import com.jervisffb.engine.rules.builder.GameVersion
 import com.jervisffb.engine.rules.common.roster.RegionalSpecialRule
 import com.jervisffb.engine.rules.common.roster.Roster
 import com.jervisffb.engine.rules.common.roster.TeamSpecialRule
 import com.jervisffb.engine.rules.common.skills.SkillType
 import com.jervisffb.engine.teamBuilder
 import com.jervisffb.fumbbl.net.model.SpecialRule
+import com.jervisffb.resources.bb2020.AMAZON_TEAM_BB2020
 import com.jervisffb.resources.bb2020.CHAOS_DWARF_TEAM_BB2020
 import com.jervisffb.resources.bb2020.ELVEN_UNION_TEAM_BB2020
 import com.jervisffb.resources.bb2020.HUMAN_TEAM_BB2020
 import com.jervisffb.resources.bb2020.KHORNE_TEAM_BB2020
+import com.jervisffb.resources.bb2020.LIZARDMEN_TEAM_BB2020
+import com.jervisffb.resources.bb2020.ORC_TEAM_BB2020
 import com.jervisffb.resources.bb2020.SKAVEN_TEAM_BB2020
+import com.jervisffb.resources.bb2025.AMAZON_TEAM_BB2025
+import com.jervisffb.resources.bb2025.CHAOS_DWARF_TEAM_BB2025
+import com.jervisffb.resources.bb2025.DWARF_TEAM_BB2025
+import com.jervisffb.resources.bb2025.ELVEN_UNION_TEAM_BB2025
+import com.jervisffb.resources.bb2025.HIGH_ELF_TEAM_BB2025
+import com.jervisffb.resources.bb2025.HUMAN_TEAM_BB2025
+import com.jervisffb.resources.bb2025.KHORNE_TEAM_BB2025
+import com.jervisffb.resources.bb2025.LIZARDMEN_TEAM_BB2025
+import com.jervisffb.resources.bb2025.NURGLE_TEAM_BB2025
+import com.jervisffb.resources.bb2025.ORC_TEAM_BB2025
+import com.jervisffb.resources.bb2025.SKAVEN_TEAM_BB2025
+import com.jervisffb.resources.bb2025.TOMB_KINGS_TEAM_BB2025
 
 typealias FumbblGame = com.jervisffb.fumbbl.net.model.Game
 typealias FumbblTeam = com.jervisffb.fumbbl.net.model.Team
@@ -42,7 +58,7 @@ fun Game.Companion.fromFumbblState(rules: Rules, game: FumbblGame): Game {
 }
 
 private fun extractTeam(rules: Rules, team: FumbblTeam): Team {
-    val roster = extractRoster(team.roster)
+    val roster = extractRoster(rules, team.roster)
     return teamBuilder(rules, roster) {
         this.name = team.teamName
         this.coach = Coach(id = CoachId(team.coach), name = team.coach)
@@ -84,35 +100,50 @@ private fun extractTeam(rules: Rules, team: FumbblTeam): Team {
                 throw IllegalStateException("Could not find matching position: ${fumbblPlayer.positionId}")
             }
             val position = roster.positions.firstOrNull { it.titleSingular == fumbblPosition.positionName }
+                ?: roster.positions.firstOrNull { it.titleSingular == mapFumbblPositionName(fumbblPosition.positionName) }
             if (position == null) {
                 throw IllegalStateException(
                     "Could not find position '${fumbblPosition.positionName}' in '${team.roster.rosterName}'",
                 )
             }
-            val skills = fumbblPlayer.skillValuesMap.map {
-                convertFumbblSkillToSkillId(rules, it.key)
-            }.filterNotNull()
+            // FUMBBL lists a player's starting (positional) and earned skills
+            // together. The roster position's skillArray holds the positional
+            // skills, so anything beyond those is an extra skill.
+            val positionalSkillTypes = fumbblPosition.skillArray
+                .mapNotNull { convertFumbblSkillToSkillId(rules, it)?.type }
+                .toSet()
+            val extraSkills = fumbblPlayer.skillArray
+                .mapNotNull { convertFumbblSkillToSkillId(rules, it) }
+                .filter { it.type !in positionalSkillTypes }
 
             addPlayer(
                 PlayerId(fumbblPlayer.playerId),
                 fumbblPlayer.playerName,
                 PlayerNo(fumbblPlayer.playerNr),
                 position,
-                skills
+                extraSkills
             )
         }
     }
 }
 
-private fun extractRoster(roster: FumbblRoster): Roster {
+private fun extractRoster(rules: Rules, roster: FumbblRoster): Roster {
     // TODO Add logic for building custom rosters, for now
     //  just refer to the original rules
+    val bb2025 = rules.baseVersion == GameVersion.BB2025
     return when (roster.rosterName) {
-        "Chaos Dwarf" -> CHAOS_DWARF_TEAM_BB2020
-        "Human" -> HUMAN_TEAM_BB2020
-        "Khorne" -> KHORNE_TEAM_BB2020
-        "Elven Union" -> ELVEN_UNION_TEAM_BB2020
-        "Skaven" -> SKAVEN_TEAM_BB2020
+        "Amazon" -> if (bb2025) AMAZON_TEAM_BB2025 else AMAZON_TEAM_BB2020
+        "Chaos Dwarf" -> if (bb2025) CHAOS_DWARF_TEAM_BB2025 else CHAOS_DWARF_TEAM_BB2020
+        "Dwarf" -> DWARF_TEAM_BB2025 // Dwarf is BB2025-only in Jervis
+        "Elven Union" -> if (bb2025) ELVEN_UNION_TEAM_BB2025 else ELVEN_UNION_TEAM_BB2020
+        "High Elf" -> HIGH_ELF_TEAM_BB2025 // High Elf is BB2025-only in Jervis
+        "Human" -> if (bb2025) HUMAN_TEAM_BB2025 else HUMAN_TEAM_BB2020
+        "Khorne" -> if (bb2025) KHORNE_TEAM_BB2025 else KHORNE_TEAM_BB2020
+        "Lizardmen" -> if (bb2025) LIZARDMEN_TEAM_BB2025 else LIZARDMEN_TEAM_BB2020
+        "Nurgle" -> NURGLE_TEAM_BB2025 // Nurgle is BB2025-only in Jervis
+        "Orc" -> if (bb2025) ORC_TEAM_BB2025 else ORC_TEAM_BB2020
+        "Skaven" -> if (bb2025) SKAVEN_TEAM_BB2025 else SKAVEN_TEAM_BB2020
+        "Tomb Kings" -> TOMB_KINGS_TEAM_BB2025 // Tomb Kings is BB2025-only in Jervis
         else -> TODO("Missing team: ${roster.rosterName}")
     }
 }
@@ -120,6 +151,31 @@ private fun extractRoster(roster: FumbblRoster): Roster {
 private fun extractField(field: FumbblField): Pitch {
     // TODO Extract more information when we know what to fetch
     return Pitch(width = 26, height = 15)
+}
+
+/**
+ * Maps FUMBBL position names to their Jervis equivalents. FUMBBL occasionally
+ * renames positions relative to the official rulebook; this bridges those gaps
+ * so the roster position lookup in [extractTeam] can match.
+ */
+private fun mapFumbblPositionName(positionName: String): String = when (positionName) {
+    "Anointed Blitzer" -> "Tomb Kings Blitzer"
+    "Anointed Thrower" -> "Tomb Kings Thrower"
+    "Chaos Dwarf Flamesmith" -> "Flamesmith"
+    "Dwarf Blocker Lineman" -> "Dwarf Lineman"
+    "Elf Blitzer" -> "Blitzer"
+    "Elf Catcher" -> "Catcher"
+    "Elf Lineman" -> "Lineman"
+    "Elf Thrower" -> "Thrower"
+    "Hobgoblin Sneaky Stabba" -> "Sneaky Stabba"
+    "Human Blitzer" -> "Blitzer"
+    "Human Catcher" -> "Catcher"
+    "Human Thrower" -> "Thrower"
+    "Minotaur" -> "Enslaved Minotaur"
+    "Skaven Clanrat" -> "Skaven Clanrat Lineman"
+    "Skaven Thrower" -> "Thrower"
+    "Skink Lineman" -> "Skink Runner Lineman"
+    else -> positionName
 }
 
 /**


### PR DESCRIPTION
`extractTeam` wrote every FUMBBL skill into `extraSkills` without filtering out the positional skills, so a player's starting skills were wrongly reported as extra skills. Dedupe the player's skills against the roster position's `skillArray (by skill type, so valued skills like Mighty Blow match correctly).

`extractRoster` hardcoded the BB2020 rosters regardless of the ruleset and only covered a few teams. Select the BB2025 vs BB2020 roster from the rules' `baseVersion` and cover every roster Jervis ships: Amazon, Chaos Dwarf, Dwarf, Elven Union, High Elf, Human, Khorne, Lizardmen, Nurgle, Orc, Skaven and Tomb Kings.

Bridge FUMBBL's renamed positions to their Jervis titles (e.g. "Skink Lineman" → "Skink Runner Lineman", "Anointed Blitzer" → "Tomb Kings Blitzer").